### PR TITLE
Thread pseudo parameter through R VAE knockoff pipeline

### DIFF
--- a/R/FLORAL.R
+++ b/R/FLORAL.R
@@ -107,7 +107,8 @@ FLORAL <- function(x,
                                   batch_size      = 50,
                                   lr              = 1e-3,
                                   weight_decay    = 1e-2,
-                                  seed            = 123),
+                                  seed            = 123,
+                                  pseudo          = 1.0),
                    intercept=FALSE,
                    foldid=NULL,
                    step2=TRUE,
@@ -179,7 +180,8 @@ FLORAL <- function(x,
                              batch_size      = 50,
                              lr              = 1e-3,
                              weight_decay    = 1e-2,
-                             seed            = 123)
+                             seed            = 123,
+                             pseudo          = 1.0)
           }
           
           res <- LogRatioGEEKN(x,
@@ -249,7 +251,8 @@ FLORAL <- function(x,
                            batch_size      = 50,
                            lr              = 1e-3,
                            weight_decay    = 1e-2,
-                           seed            = 123)
+                           seed            = 123,
+                           pseudo          = 1.0)
         }
         
         res <- LogRatioLassoKN(x,
@@ -327,7 +330,8 @@ FLORAL <- function(x,
                              batch_size      = 50,
                              lr              = 1e-3,
                              weight_decay    = 1e-2,
-                             seed            = 123)
+                             seed            = 123,
+                             pseudo          = 1.0)
           }
           
           res <- LogRatioGEEKN(x,
@@ -397,7 +401,8 @@ FLORAL <- function(x,
                            batch_size      = 50,
                            lr              = 1e-3,
                            weight_decay    = 1e-2,
-                           seed            = 123)
+                           seed            = 123,
+                           pseudo          = 1.0)
         }
         
         res <- LogRatioLogisticLassoKN(x,
@@ -478,7 +483,8 @@ FLORAL <- function(x,
                              batch_size      = 50,
                              lr              = 1e-3,
                              weight_decay    = 1e-2,
-                             seed            = 123)
+                             seed            = 123,
+                             pseudo          = 1.0)
           }
           
           res <- LogRatioTDCoxLassoKN(newx,
@@ -536,7 +542,8 @@ FLORAL <- function(x,
                            batch_size      = 50,
                            lr              = 1e-3,
                            weight_decay    = 1e-2,
-                           seed            = 123)
+                           seed            = 123,
+                           pseudo          = 1.0)
         }
         
         res <- LogRatioCoxLassoKN(x,
@@ -625,7 +632,8 @@ FLORAL <- function(x,
                              batch_size      = 50,
                              lr              = 1e-3,
                              weight_decay    = 1e-2,
-                             seed            = 123)
+                             seed            = 123,
+                             pseudo          = 1.0)
           }
           
           res <- LogRatioFGLassoKN(newx,
@@ -702,7 +710,8 @@ FLORAL <- function(x,
                            batch_size      = 50,
                            lr              = 1e-3,
                            weight_decay    = 1e-2,
-                           seed            = 123)
+                           seed            = 123,
+                           pseudo          = 1.0)
         }
         
         res <- LogRatioFGLassoKN(newx,

--- a/R/LogRatioCoxLassoKN.R
+++ b/R/LogRatioCoxLassoKN.R
@@ -60,7 +60,8 @@ LogRatioCoxLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -85,7 +86,8 @@ LogRatioCoxLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/LogRatioFGLassoKN.R
+++ b/R/LogRatioFGLassoKN.R
@@ -65,7 +65,8 @@ LogRatioFGLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -90,7 +91,8 @@ LogRatioFGLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/LogRatioGEEKN.R
+++ b/R/LogRatioGEEKN.R
@@ -51,7 +51,8 @@ LogRatioGEEKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -76,7 +77,8 @@ LogRatioGEEKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/LogRatioLassoKN.R
+++ b/R/LogRatioLassoKN.R
@@ -45,7 +45,8 @@ LogRatioLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -70,7 +71,8 @@ LogRatioLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/LogRatioLogisticLassoKN.R
+++ b/R/LogRatioLogisticLassoKN.R
@@ -45,7 +45,8 @@ LogRatioLogisticLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -70,7 +71,8 @@ LogRatioLogisticLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/LogRatioTDCoxLassoKN.R
+++ b/R/LogRatioTDCoxLassoKN.R
@@ -66,7 +66,8 @@ LogRatioTDCoxLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }else{
@@ -91,7 +92,8 @@ LogRatioTDCoxLassoKN <- function(x,
                       kn_method$lr,
                       kn_method$weight_decay,
                       kn_method$seed,
-                      progress=progress)$knockoff_x
+                      progress=progress,
+                      pseudo=kn_method$pseudo)$knockoff_x
     }
     
   }

--- a/R/py_wrapper.R
+++ b/R/py_wrapper.R
@@ -19,6 +19,7 @@
 #' @param weight_decay Weight decay for optimizer (default: 1e-2)
 #' @param seed Random seed (default: 123)
 #' @param progress Logical. If TRUE (default), prints epoch progress every 10 epochs.
+#' @param pseudo Pseudo count used in the original log-transformation log(count + pseudo). Default 1.0.
 #'
 #' @return A list with components:
 #'   \item{knockoff_x}{Generated knockoff data matrix}
@@ -40,7 +41,8 @@ train_vae <- function(x,
                       lr              = 1e-3,
                       weight_decay    = 1e-2,
                       seed            = 123,
-                      progress        = TRUE) {
+                      progress        = TRUE,
+                      pseudo          = 1.0) {
   
   # Check if Python is available
   if (!reticulate::py_available()) {
@@ -135,7 +137,8 @@ train_vae <- function(x,
       lr = as.numeric(lr),
       weight_decay = as.numeric(weight_decay),
       seed = as.integer(seed),
-      progress = as.logical(progress)
+      progress = as.logical(progress),
+      pseudo = as.numeric(pseudo)
     )
   }, error = function(e) {
     # Provide more informative error messages


### PR DESCRIPTION
## What changed

The Python `VAE_func_DK` function already accepted a `pseudo` count parameter (introduced in #44) and used it to compute `log_pseudo` for the presence/absence decoder mask. However, the R side never wired it through:

- `train_vae()` in `py_wrapper.R` had no `pseudo` parameter and did not pass one to Python, so the mask always defaulted to `pseudo=1.0` regardless of what pseudo count was used in the upstream log-transformation.
- All six KN model files (`LogRatioLassoKN`, `LogRatioCoxLassoKN`, `LogRatioTDCoxLassoKN`, `LogRatioLogisticLassoKN`, `LogRatioFGLassoKN`, `LogRatioGEEKN`) called `train_vae()` without forwarding `pseudo`.

## Changes

- **`R/py_wrapper.R`**: Added `pseudo = 1.0` parameter to `train_vae()` signature; passes it as `pseudo = as.numeric(pseudo)` to `VAE_func_DK_py()`.
- **`R/FLORAL.R`**: Added `pseudo = 1.0` to all 9 `kn_method` default list constructions.
- **6 KN model files**: Added `pseudo = kn_method$pseudo` to every `train_vae()` call (12 call sites total).

## Notes for reviewer

The default `pseudo = 1.0` matches the Python default, so all existing behaviour is preserved. Users who pass a non-default `pseudo` to `FLORAL()` and use VAE knockoffs will now have the correct mask threshold propagated to the Python VAE.