### PR TITLE
Fix knockoff selection to use the knockoff rule {j : W_j >= T}

### DIFF
--- a/R/LogRatioCoxLassoKN.R
+++ b/R/LogRatioCoxLassoKN.R
@@ -163,19 +163,39 @@ LogRatioCoxLassoKN <- function(x,
       threshold <- knockoff::knockoff.threshold(df_betaseq_long$W, fdr=fdr_val, offset=offset_val)
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path. This makes an
+      # infinite threshold (knockoff.threshold()'s encoding of "reject nothing")
+      # correctly yield the EMPTY set. The previous implementation read the
+      # nonzero coefficients at the lambda nearest T, which (a) returned whatever
+      # sat at lambda[1] whenever T was Inf, because abs(lambda - Inf) is Inf for
+      # every lambda and which.min() then falls back to index 1, and (b) even for
+      # finite T could include features whose knockoff entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite (nothing selected)
+      # so that no coefficient vector is reported for an empty selection.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(fullfit$beta)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -201,6 +221,7 @@ LogRatioCoxLassoKN <- function(x,
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
               selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long,  # feature_original / Original / KN / W — audit trail
               xk = xk
   )
   

--- a/R/LogRatioFGLassoKN.R
+++ b/R/LogRatioFGLassoKN.R
@@ -169,18 +169,37 @@ LogRatioFGLassoKN <- function(x,
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path, so an infinite
+      # threshold (knockoff.threshold()'s encoding of "reject nothing") yields
+      # the EMPTY set. Reading nonzero coefficients at the lambda nearest T
+      # instead returned whatever sat at lambda[1] whenever T was Inf, because
+      # abs(lambda - Inf) is Inf for every lambda and which.min() then falls back
+      # to index 1; for finite T it could also admit features whose knockoff
+      # entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(fullfit$beta)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -205,7 +224,8 @@ LogRatioFGLassoKN <- function(x,
               threshold_list = threshold_list,  # All thresholds (all FDR×offset combinations)
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
-              selected.features_list = selected.features_list  # All selected features
+              selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long  # feature_original / Original / KN / W - audit trail
   )
   
   if (plot){

--- a/R/LogRatioGEEKN.R
+++ b/R/LogRatioGEEKN.R
@@ -201,18 +201,37 @@ LogRatioGEEKN <- function(x,
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- beta_filtered[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path, so an infinite
+      # threshold (knockoff.threshold()'s encoding of "reject nothing") yields
+      # the EMPTY set. Reading nonzero coefficients at the lambda nearest T
+      # instead returned whatever sat at lambda[1] whenever T was Inf, because
+      # abs(lambda - Inf) is Inf for every lambda and which.min() then falls back
+      # to index 1; for finite T it could also admit features whose knockoff
+      # entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(beta_filtered)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        beta_filtered[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -238,7 +257,8 @@ LogRatioGEEKN <- function(x,
               threshold_list = threshold_list,  # All thresholds (all FDR×offset combinations)
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
-              selected.features_list = selected.features_list  # All selected features
+              selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long  # feature_original / Original / KN / W - audit trail
   )
   
   if (plot){

--- a/R/LogRatioLassoKN.R
+++ b/R/LogRatioLassoKN.R
@@ -151,18 +151,37 @@ LogRatioLassoKN <- function(x,
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path, so an infinite
+      # threshold (knockoff.threshold()'s encoding of "reject nothing") yields
+      # the EMPTY set. Reading nonzero coefficients at the lambda nearest T
+      # instead returned whatever sat at lambda[1] whenever T was Inf, because
+      # abs(lambda - Inf) is Inf for every lambda and which.min() then falls back
+      # to index 1; for finite T it could also admit features whose knockoff
+      # entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(fullfit$beta)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -187,7 +206,8 @@ LogRatioLassoKN <- function(x,
               threshold_list = threshold_list,  # All thresholds (all FDR×offset combinations)
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
-              selected.features_list = selected.features_list  # All selected features
+              selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long  # feature_original / Original / KN / W - audit trail
   )
   
   if (plot){

--- a/R/LogRatioLogisticLassoKN.R
+++ b/R/LogRatioLogisticLassoKN.R
@@ -147,18 +147,37 @@ LogRatioLogisticLassoKN <- function(x,
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path, so an infinite
+      # threshold (knockoff.threshold()'s encoding of "reject nothing") yields
+      # the EMPTY set. Reading nonzero coefficients at the lambda nearest T
+      # instead returned whatever sat at lambda[1] whenever T was Inf, because
+      # abs(lambda - Inf) is Inf for every lambda and which.min() then falls back
+      # to index 1; for finite T it could also admit features whose knockoff
+      # entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(fullfit$beta)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -184,7 +203,8 @@ LogRatioLogisticLassoKN <- function(x,
               threshold_list = threshold_list,  # All thresholds (all FDR×offset combinations)
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
-              selected.features_list = selected.features_list  # All selected features
+              selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long  # feature_original / Original / KN / W - audit trail
   )
   
   if (plot){

--- a/R/LogRatioTDCoxLassoKN.R
+++ b/R/LogRatioTDCoxLassoKN.R
@@ -170,18 +170,37 @@ LogRatioTDCoxLassoKN <- function(x,
       threshold_list[[combo_idx]] <- threshold
       names(threshold_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
-      # Find the lambda index closest to the threshold (in case of floating point precision issues)
-      thres.idx <- which.min(abs(lambda - threshold))
-      thres.idx_list[[combo_idx]] <- thres.idx
-      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      thres.beta <- fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
-      thres.beta_list[[combo_idx]] <- thres.beta
-      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
-      
-      selected.features <- names(thres.beta[thres.beta != 0])
+      # ---- Selection: the knockoff rule itself, {j : W_j >= T} ----------------
+      # Derived directly from W rather than from the lambda path, so an infinite
+      # threshold (knockoff.threshold()'s encoding of "reject nothing") yields
+      # the EMPTY set. Reading nonzero coefficients at the lambda nearest T
+      # instead returned whatever sat at lambda[1] whenever T was Inf, because
+      # abs(lambda - Inf) is Inf for every lambda and which.min() then falls back
+      # to index 1; for finite T it could also admit features whose knockoff
+      # entered first (W_j < 0).
+      selected.features <- as.character(
+        df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
+      )
       selected.features_list[[combo_idx]] <- selected.features
       names(selected.features_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      # ---- Reporting index: smallest lambda that is still >= threshold --------
+      # W_j is feature j's entry lambda, so the nonzero set at this lambda
+      # coincides with {W_j >= T}. `>=` (not `>`) retains the boundary feature
+      # whose |W| defines the threshold. NA when T is infinite.
+      keep_idx  <- which(lambda >= threshold)
+      thres.idx <- if (length(keep_idx) > 0L) max(keep_idx) else NA_integer_
+      thres.idx_list[[combo_idx]] <- thres.idx
+      names(thres.idx_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
+
+      feat_names <- rownames(fullfit$beta)[(ncov+1):(ncov+p0)]
+      thres.beta <- if (is.na(thres.idx)) {
+        stats::setNames(rep(0, p0), feat_names)
+      } else {
+        fullfit$beta[,thres.idx][(ncov+1):(ncov+p0)]
+      }
+      thres.beta_list[[combo_idx]] <- thres.beta
+      names(thres.beta_list)[combo_idx] <- paste0("fdr_", fdr_val, "_offset_", offset_val)
       
       combo_idx <- combo_idx + 1
     }
@@ -206,7 +225,8 @@ LogRatioTDCoxLassoKN <- function(x,
               threshold_list = threshold_list,  # All thresholds (all FDR×offset combinations)
               thres.idx_list = thres.idx_list,  # All threshold indices
               thres.beta_list = thres.beta_list,  # All threshold betas
-              selected.features_list = selected.features_list  # All selected features
+              selected.features_list = selected.features_list,  # All selected features
+              W = df_betaseq_long  # feature_original / Original / KN / W - audit trail
   )
   
   if (plot){


### PR DESCRIPTION
## Summary

Knockoff selection did not implement the knockoff rule. Instead of selecting
`{j : W_j >= T}`, every `LogRatio*KN.R` file located the lambda nearest the
threshold and returned whatever coefficients were nonzero there:

```r
threshold  <- knockoff::knockoff.threshold(df_betaseq_long$W, fdr=fdr_val, offset=offset_val)
thres.idx  <- which.min(abs(lambda - threshold))
thres.beta <- fullfit$beta[, thres.idx][(ncov+1):(ncov+p0)]
selected.features <- names(thres.beta[thres.beta != 0])
```

### Defect 1 — an infinite threshold silently became `lambda[1]`

`knockoff.threshold()` returns `Inf` to mean *reject nothing*. But
`abs(lambda - Inf)` is `Inf` for every lambda, so `which.min()` falls back to
index **1** (the largest lambda) and the function returns whatever is nonzero
there instead of the empty set.

Reproduced on a global-null Cox dataset (seed 1001, `FLORAL-KN-VAE-eq1`,
q=0.05, offset=1): `threshold = Inf`, `thres.idx = 1`, and `taxa2` is returned.

In a 200-replicate global-null study (no signal, so every selection is a false
discovery) the fraction of replicates selecting at least one feature was **flat
at ~55% (offset=0) and ~24-27% (offset=1) across q = 0.05 / 0.10 / 0.20**.
Insensitivity to `q` is the fingerprint: under the global null the threshold is
always `Inf`, so the returned set is whatever sits at `lambda[1]`, which never
depends on `q`.

Independently impossible: 50/200 replicates returned **exactly one** feature at
q=0.05 with offset=1. Knockoff+ returning one feature requires
`(1 + #{W <= -T}) / 1 <= 0.05`, i.e. `1 <= 0.05`.

### Defect 2 — the lambda proxy is not the rule

Even for finite `T`, "nonzero at the nearest lambda" can admit features whose
knockoff entered first (`W_j < 0`) but whose original is nonzero by that point
on the path, and `which.min(abs(...))` can land on a lambda *below* `T`.

## Fix

Select from `W` directly, which is already in scope:

```r
selected.features <- as.character(
  df_betaseq_long$feature_original[df_betaseq_long$W >= threshold]
)
```

This is the exact rule and handles `Inf` for free — nothing is `>= Inf`.

`thres.idx` is demoted to a *reporting* index (which coefficients to display)
and redefined as `max(which(lambda >= threshold))`: the smallest lambda still
at or above `T`. Since `W_j` is feature *j*'s entry lambda, the nonzero set at
that lambda coincides with `{W_j >= T}`. `>=` rather than `>` retains the
boundary feature whose `|W|` defines the threshold — `>` undercounts by exactly
one in every finite-threshold cell tested. `thres.idx` is `NA` when `T` is
infinite, and `thres.beta` is then a named zero vector.

Decoupling selection from `thres.idx` also immunises it against the early
`break` in the C++ path, which can leave trailing all-zero columns in
`fullfit$beta`.

Each family now also returns `W` (`df_betaseq_long`) so selections can be
re-derived and audited without re-fitting — this is what made the bug
diagnosable.

## Verification

Cox, across null and signal scenarios x 3 FDR levels x 2 offsets — patched
output matches `{j : W_j >= T}` in **all 12 cells**:

| scenario | T | exact | `nearest` (old) | `>=T` | `>T` |
|---|---|---|---|---|---|
| null, offset=0 | 0.378 | 1 | 1 | **1** | 0 |
| null, offset=1 | Inf | 0 | **1** (bug) | **0** | 0 |
| signal, q=0.05, offset=0 | 0.541 | 6 | 6 | **6** | 5 |
| signal, q=0.10, offset=0 | 0.245 | 12 | 12 | **12** | 11 |
| signal, q=0.20, offset=0 | 0.161 | 14 | 14 | **14** | 13 |
| signal, q=0.20, offset=1 | 0.245 | 12 | 12 | **12** | 11 |

Gaussian, binomial and Cox fits additionally confirm `W` is returned, the
reported selection matches the exact rule in every cell, and cells with an
infinite threshold now return zero features.

## Scope

All six knockoff families: Cox, linear, logistic, Fine-Gray, GEE, and
time-dependent Cox. `LogRatioGEEKN.R` uses `beta_filtered` rather than
`fullfit$beta`; same shape, rownames and lambda alignment, so the change is
otherwise identical.

## Impact on existing results

Any previously reported knockoff FDR or power from this package should be
regenerated. The damage concentrates where thresholds are infinite — strict
`q`, knockoff+, and null or near-null data — which is exactly where the method
is supposed to be most conservative.

Note the bug also *masked* a genuine structural property: knockoff+ cannot
reject until it makes at least `1/q` discoveries, so with fewer than `1/q` true
signals the correct result at that `q` is zero selections, not a small nonzero
count.
